### PR TITLE
Overwrite global MediaQuery and fixed overlap display bug. 

### DIFF
--- a/Lime/Lime.css
+++ b/Lime/Lime.css
@@ -2,6 +2,13 @@
 @import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css);
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 
+@media (max-width:1280px) {
+    
+#userinfo ul  {
+    display: flex !important;
+}
+}
+
 * {
 font-family: Roboto;
 }

--- a/Lime/Lime.css
+++ b/Lime/Lime.css
@@ -2,12 +2,16 @@
 @import url(https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css);
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 
-@media (max-width:1280px) {
-    
+@media (max-width:1280px) {    
 #userinfo ul  {
     display: flex !important;
 }
+#userinfo_username, #userinfo_minor{
+    flex-direction: column;
+    flex-wrap: nowrap;
 }
+}
+
 
 * {
 font-family: Roboto;


### PR DESCRIPTION
global.css changes display to block below 1280px. This messes with styles' flex display for userinfo in header.

Added media query here to override that. And included flex properties to fix horizontal dropdown bug for username and minor_info.