### PR TITLE
Fixed pre BBCode font.

### DIFF
--- a/Lime/Lime.css
+++ b/Lime/Lime.css
@@ -28,6 +28,14 @@ textarea:active,
 textarea:focus {
     outline: 0
 }
+
+pre, xmp, plaintext, listing {
+display: block;
+font-family: monospace;
+white-space: pre;
+margin: 1em 0px;
+}
+
 #content>.thin,
 .box,
 .box2,

--- a/Lime/Lime.css
+++ b/Lime/Lime.css
@@ -26,7 +26,7 @@ select:active,
 select:focus,
 textarea:active,
 textarea:focus {
-    outline: 0
+    outline: 0;
 }
 
 pre, xmp, plaintext, listing {

--- a/Lime/Lime.css
+++ b/Lime/Lime.css
@@ -36,6 +36,10 @@ white-space: pre;
 margin: 1em 0px;
 }
 
+tt, code, kbd, samp {
+font-family: monospace;
+}
+
 #content>.thin,
 .box,
 .box2,


### PR DESCRIPTION
Font for pre, xmp, plaintext, listing changed to monospace, with proper white spacing and margin.